### PR TITLE
Added buy and sell commands.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "jest"
   ],
   "env": {
+    "es6": true,
     "jest": true
   },
   "globals": {

--- a/md-seed-config.js
+++ b/md-seed-config.js
@@ -4,7 +4,9 @@ mongooseLib.Promise = global.Promise;
 import Areas from './seeders/areas.seeder';
 import Characters from './seeders/characters.seeder';
 import Rooms from './seeders/rooms.seeder';
+import Shops from './seeders/shops.seeder';
 import Users from './seeders/users.seeder';
+
 
 // Export the mongoose lib
 export const mongoose = mongooseLib;
@@ -23,5 +25,6 @@ export const seedersList = {
   Areas,
   Characters,
   Rooms,
+  Shops,
   Users,
 };

--- a/seeders/areas.seeder.js
+++ b/seeders/areas.seeder.js
@@ -7,6 +7,11 @@ const data = [
     "_id": Types.ObjectId("5b74b9ca62976d41dae0c288"),
     "name": "Infernal Chasm",
     "__v": 0
+  },
+  {
+    "_id": Types.ObjectId("5b779e8971dfb628458e4d36"),
+    "name": "Eastmark",
+    "__v": 0
   }
 ];
 

--- a/seeders/rooms.seeder.js
+++ b/seeders/rooms.seeder.js
@@ -4,31 +4,6 @@ import { Types } from 'mongoose';
 
 const data = [
   {
-    "_id": Types.ObjectId("5b74b95c7bf1c641880250fe"),
-    "name": "Ye Olde Welcome Room",
-    "desc": "Dusty training implements line the walls of this empty chamber.",
-    "x": 0,
-    "y": 0,
-    "z": 0,
-    "inventory": [],
-    "exits": [
-      {
-        "_id": Types.ObjectId("5b74b9a762976d41dae0c287"),
-        "roomId": "5b74b9a762976d41dae0c285",
-        "dir": "s"
-      }
-    ],
-    "__v": 1,
-    "spawner": {
-      "mobTypes": [
-        "dummy"
-      ],
-      "_id": Types.ObjectId("5b74c198ec3b5648a800d6fb"),
-      "max": 1,
-      "timeout": 5000
-    }
-  },
-  {
     "_id": Types.ObjectId("5b74b9a762976d41dae0c285"),
     "name": "Cursed Gateway",
     "desc": "The door to the south flickers with energy.",
@@ -36,24 +11,24 @@ const data = [
     "x": 0,
     "y": -1,
     "z": 0,
+    "__v": 0,
+    "area": "5b74b9ca62976d41dae0c288",
     "inventory": [],
     "exits": [
-      {
-        "dir": "n",
-        "roomId": "5b74b95c7bf1c641880250fe",
-        "_id": Types.ObjectId("5b74b9a762976d41dae0c286")
-      },
-      {
-        "_id": Types.ObjectId("5b74ba0062976d41dae0c28b"),
-        "roomId": "5b74ba0062976d41dae0c289",
-        "dir": "s",
-        "closed": false
-      }
-    ],
-    "__v": 1,
-    "area": "5b74b9ca62976d41dae0c288"
-  },
-  {
+        {
+            "dir": "n",
+            "roomId": "5b74b95c7bf1c641880250fe",
+            "_id": Types.ObjectId("5b74b9a762976d41dae0c286")
+        },
+        {
+            "_id": Types.ObjectId("5b74ba0062976d41dae0c28b"),
+            "roomId": "5b74ba0062976d41dae0c289",
+            "dir": "s",
+            "closed": false
+        }
+    ]
+},
+{
     "_id": Types.ObjectId("5b74ba0062976d41dae0c289"),
     "name": "Entryway",
     "desc": "This room seems to give off its own heat, and the breeze from the south carries floating cinders.",
@@ -61,28 +36,58 @@ const data = [
     "x": 0,
     "y": -2,
     "z": 0,
+    "__v": 0,
+    "area": "5b74b9ca62976d41dae0c288",
     "inventory": [],
     "exits": [
-      {
-        "dir": "n",
-        "roomId": "5b74b9a762976d41dae0c285",
-        "_id": Types.ObjectId("5b74ba0062976d41dae0c28a")
-      },
-      {
-        "_id": Types.ObjectId("5b74bbfc959cbe4520536873"),
-        "roomId": "5b74bbfc959cbe4520536871",
-        "dir": "e"
-      },
-      {
-        "_id": Types.ObjectId("5b74be6a959cbe4520536876"),
-        "roomId": "5b74be6a959cbe4520536874",
-        "dir": "s"
-      }
-    ],
-    "__v": 2,
-    "area": "5b74b9ca62976d41dae0c288"
-  },
-  {
+        {
+            "dir": "n",
+            "roomId": "5b74b9a762976d41dae0c285",
+            "_id": Types.ObjectId("5b74ba0062976d41dae0c28a")
+        },
+        {
+            "_id": Types.ObjectId("5b74bbfc959cbe4520536873"),
+            "roomId": "5b74bbfc959cbe4520536871",
+            "dir": "e"
+        },
+        {
+            "_id": Types.ObjectId("5b74be6a959cbe4520536876"),
+            "roomId": "5b74be6a959cbe4520536874",
+            "dir": "s"
+        }
+    ]
+},
+{
+    "_id": Types.ObjectId("5b74b95c7bf1c641880250fe"),
+    "name": "Ye Olde Welcome Room",
+    "desc": "Dusty training implements line the walls of this empty chamber.",
+    "x": 0,
+    "y": 0,
+    "z": 0,
+    "__v": 1,
+    "spawner": {
+        "_id": Types.ObjectId("5b74c198ec3b5648a800d6fb"),
+        "max": 1,
+        "timeout": 5000,
+        "mobTypes": [
+            "dummy"
+        ]
+    },
+    "inventory": [],
+    "exits": [
+        {
+            "_id": Types.ObjectId("5b74b9a762976d41dae0c287"),
+            "roomId": "5b74b9a762976d41dae0c285",
+            "dir": "s"
+        },
+        {
+            "_id": Types.ObjectId("5b779e2471dfb628458e4d2d"),
+            "roomId": "5b779e2471dfb628458e4d2b",
+            "dir": "e"
+        }
+    ]
+},
+{
     "_id": Types.ObjectId("5b74bbfc959cbe4520536871"),
     "area": "5b74b9ca62976d41dae0c288",
     "name": "Dead End",
@@ -90,17 +95,17 @@ const data = [
     "x": 1,
     "y": -2,
     "z": 0,
+    "__v": 0,
     "inventory": [],
     "exits": [
-      {
-        "dir": "w",
-        "roomId": "5b74ba0062976d41dae0c289",
-        "_id": Types.ObjectId("5b74bbfc959cbe4520536872")
-      }
-    ],
-    "__v": 0
-  },
-  {
+        {
+            "dir": "w",
+            "roomId": "5b74ba0062976d41dae0c289",
+            "_id": Types.ObjectId("5b74bbfc959cbe4520536872")
+        }
+    ]
+},
+{
     "_id": Types.ObjectId("5b74be6a959cbe4520536874"),
     "area": "5b74b9ca62976d41dae0c288",
     "name": "Passage",
@@ -108,53 +113,22 @@ const data = [
     "x": 0,
     "y": -3,
     "z": 0,
+    "__v": 0,
     "inventory": [],
     "exits": [
-      {
-        "dir": "n",
-        "roomId": "5b74ba0062976d41dae0c289",
-        "_id": Types.ObjectId("5b74be6a959cbe4520536875")
-      },
-      {
-        "_id": Types.ObjectId("5b74beab959cbe4520536879"),
-        "roomId": "5b74beab959cbe4520536877",
-        "dir": "s"
-      }
-    ],
-    "__v": 1
-  },
-  {
-    "_id": Types.ObjectId("5b74beab959cbe4520536877"),
-    "area": "5b74b9ca62976d41dae0c288",
-    "name": "Dark Altar",
-    "desc": "An altar and pews are arranged around a staircase leading below.",
-    "x": 0,
-    "y": -4,
-    "z": 0,
-    "inventory": [],
-    "exits": [
-      {
-        "dir": "n",
-        "roomId": "5b74be6a959cbe4520536874",
-        "_id": Types.ObjectId("5b74beab959cbe4520536878")
-      },
-      {
-        "_id": Types.ObjectId("5b74bed4959cbe452053687c"),
-        "roomId": "5b74bed4959cbe452053687a",
-        "dir": "d"
-      }
-    ],
-    "__v": 1,
-    "spawner": {
-      "mobTypes": [
-        "cultist"
-      ],
-      "_id": Types.ObjectId("5b74c112ec3b5648a800d6f6"),
-      "max": 3,
-      "timeout": 20000
-    }
-  },
-  {
+        {
+            "dir": "n",
+            "roomId": "5b74ba0062976d41dae0c289",
+            "_id": Types.ObjectId("5b74be6a959cbe4520536875")
+        },
+        {
+            "_id": Types.ObjectId("5b74beab959cbe4520536879"),
+            "roomId": "5b74beab959cbe4520536877",
+            "dir": "s"
+        }
+    ]
+},
+{
     "_id": Types.ObjectId("5b74bed4959cbe452053687a"),
     "area": "5b74b9ca62976d41dae0c288",
     "name": "Summoning Pit",
@@ -162,24 +136,211 @@ const data = [
     "x": 0,
     "y": -4,
     "z": -1,
-    "inventory": [],
-    "exits": [
-      {
-        "dir": "u",
-        "roomId": "5b74beab959cbe4520536877",
-        "_id": Types.ObjectId("5b74bed4959cbe452053687b")
-      }
-    ],
     "__v": 0,
     "spawner": {
-      "mobTypes": [
-        "hellhound"
-      ],
-      "_id": Types.ObjectId("5b74c0b1ec3b5648a800d6f3"),
-      "max": 2,
-      "timeout": 30000
-    }
-  }];
+        "_id": Types.ObjectId("5b74c0b1ec3b5648a800d6f3"),
+        "max": 2,
+        "timeout": 30000,
+        "mobTypes": [
+            "hellhound"
+        ]
+    },
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "u",
+            "roomId": "5b74beab959cbe4520536877",
+            "_id": Types.ObjectId("5b74bed4959cbe452053687b")
+        }
+    ]
+},
+{
+    "_id": Types.ObjectId("5b74beab959cbe4520536877"),
+    "area": "5b74b9ca62976d41dae0c288",
+    "name": "Dark Altar",
+    "desc": "An altar and pews are arranged around a staircase leading below.",
+    "x": 0,
+    "y": -4,
+    "z": 0,
+    "__v": 0,
+    "spawner": {
+        "_id": Types.ObjectId("5b74c112ec3b5648a800d6f6"),
+        "max": 3,
+        "timeout": 20000,
+        "mobTypes": [
+            "cultist"
+        ]
+    },
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "n",
+            "roomId": "5b74be6a959cbe4520536874",
+            "_id": Types.ObjectId("5b74beab959cbe4520536878")
+        },
+        {
+            "_id": Types.ObjectId("5b74bed4959cbe452053687c"),
+            "roomId": "5b74bed4959cbe452053687a",
+            "dir": "d"
+        }
+    ]
+},
+{
+    "_id": Types.ObjectId("5b779e2471dfb628458e4d2b"),
+    "name": "Town Gates",
+    "desc": "The gates of Eastmark",
+    "x": 1,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b74b95c7bf1c641880250fe",
+            "_id": Types.ObjectId("5b779e2471dfb628458e4d2c")
+        },
+        {
+            "_id": Types.ObjectId("5b779e6971dfb628458e4d35"),
+            "roomId": "5b779e6971dfb628458e4d33",
+            "dir": "e",
+            "closed": true
+        }
+    ],
+    "__v": 1
+},
+{
+    "_id": Types.ObjectId("5b779e6971dfb628458e4d33"),
+    "name": "Merchant Street, west end",
+    "desc": "A muddy road.",
+    "x": 2,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b779e2471dfb628458e4d2b",
+            "_id": Types.ObjectId("5b779e6971dfb628458e4d34")
+        },
+        {
+            "_id": Types.ObjectId("5b779f15f25fe128bd016f66"),
+            "roomId": "5b779f15f25fe128bd016f64",
+            "dir": "e"
+        },
+        {
+            "_id": Types.ObjectId("5b779fd3f25fe128bd016f72"),
+            "roomId": "5b779fd3f25fe128bd016f70",
+            "dir": "s"
+        }
+    ],
+    "__v": 2,
+    "area": "5b779e8971dfb628458e4d36"
+},
+{
+    "_id": Types.ObjectId("5b779f15f25fe128bd016f64"),
+    "area": "5b779e8971dfb628458e4d36",
+    "name": "Merchant Street",
+    "desc": "A muddy road.",
+    "x": 3,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b779e6971dfb628458e4d33",
+            "_id": Types.ObjectId("5b779f15f25fe128bd016f65")
+        },
+        {
+            "_id": Types.ObjectId("5b779f4af25fe128bd016f69"),
+            "roomId": "5b779f4af25fe128bd016f67",
+            "dir": "e"
+        }
+    ],
+    "__v": 1
+},
+{
+    "_id": Types.ObjectId("5b779f4af25fe128bd016f67"),
+    "area": "5b779e8971dfb628458e4d36",
+    "name": "Town Square",
+    "desc": "The center of town.",
+    "x": 4,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b779f15f25fe128bd016f64",
+            "_id": Types.ObjectId("5b779f4af25fe128bd016f68")
+        },
+        {
+            "_id": Types.ObjectId("5b779f58f25fe128bd016f6c"),
+            "roomId": "5b779f58f25fe128bd016f6a",
+            "dir": "e"
+        }
+    ],
+    "__v": 1
+},
+{
+    "_id": Types.ObjectId("5b779f58f25fe128bd016f6a"),
+    "area": "5b779e8971dfb628458e4d36",
+    "name": "Merchant Street, east end",
+    "desc": "A muddy road.",
+    "x": 5,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b779f4af25fe128bd016f67",
+            "_id": Types.ObjectId("5b779f58f25fe128bd016f6b")
+        },
+        {
+            "_id": Types.ObjectId("5b779f69f25fe128bd016f6f"),
+            "roomId": "5b779f69f25fe128bd016f6d",
+            "dir": "e"
+        }
+    ],
+    "__v": 1
+},
+{
+    "_id": Types.ObjectId("5b779f69f25fe128bd016f6d"),
+    "area": "5b779e8971dfb628458e4d36",
+    "name": "Default Room Name",
+    "desc": "Room Description",
+    "x": 6,
+    "y": 0,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "w",
+            "roomId": "5b779f58f25fe128bd016f6a",
+            "_id": Types.ObjectId("5b779f69f25fe128bd016f6e")
+        }
+    ],
+    "__v": 0
+},
+{
+    "_id": Types.ObjectId("5b779fd3f25fe128bd016f70"),
+    "area": "5b779e8971dfb628458e4d36",
+    "name": "General Store",
+    "desc": "The general store is lined with goods.",
+    "x": 2,
+    "y": -1,
+    "z": 0,
+    "inventory": [],
+    "exits": [
+        {
+            "dir": "n",
+            "roomId": "5b779e6971dfb628458e4d33",
+            "_id": Types.ObjectId("5b779fd3f25fe128bd016f71")
+        }
+    ],
+    "__v": 0
+}];
 
 class RoomsSeeder extends Seeder {
 

--- a/seeders/shops.seeder.js
+++ b/seeders/shops.seeder.js
@@ -1,0 +1,37 @@
+import { Seeder } from 'mongoose-data-seed';
+import Shop from '../src/models/shop';
+import { Types } from 'mongoose';
+
+const data = [
+  {
+    "_id": Types.ObjectId("5b77bd754d2d7858611e1293"),
+    "roomId": "5b779fd3f25fe128bd016f70",
+    "stock": [
+      {
+        "itemTypeName": "shortsword",
+        "quantity": 10,
+        "_id": Types.ObjectId("5b77be4b492a2f5a3654f909")
+      },
+      {
+        "itemTypeName": "torch",
+        "quantity": 20,
+        "_id": Types.ObjectId("5b77c667422dac6893dfb922")
+      }
+    ],
+    "__v": 2,
+    "currency": 32
+  }
+];
+
+class ShopsSeeder extends Seeder {
+
+  async shouldRun() {
+    return Shop.count().exec().then(count => count === 0);
+  }
+
+  async run() {
+    return Shop.create(data);
+  }
+}
+
+export default ShopsSeeder;

--- a/src/commands/buy.js
+++ b/src/commands/buy.js
@@ -1,0 +1,49 @@
+import Shop from '../models/shop';
+
+export default {
+  name: 'buy',
+
+  patterns: [
+    /^buy\s+(.+)$/i,
+    /^buy\s.*/i,
+  ],
+
+  dispatch(socket, match) {
+    if (match.length != 2) {
+      this.help(socket);
+    }
+    this.execute(socket, match[1]);
+  },
+
+  execute(socket, itemName) {
+
+    const shop = Shop.getById(socket.character.roomId);
+    if (!shop) {
+      socket.emit('output', { message: 'This command can only be used in a shop.' });
+      return;
+    }
+
+    const itemType = shop.getItemTypeByAutocomplete(itemName);
+    if(!itemType) {
+      socket.emit('output', { message: 'This shop does not deal in those types of items.' });
+    }
+
+    // check if user has money
+    if (socket.character.currency < itemType.price) {
+      socket.emit('output', { message: 'You cannot afford that.' });
+      return;
+    }
+
+    const item = shop.buy(socket.character, itemType);
+    if (item) {
+      socket.emit('output', { message: 'Item purchased.' });
+      socket.broadcast.to(socket.character.roomId).emit('output', { message: `${socket.user.username} buys ${item.displayName} from the shop.` });
+    }
+  },
+
+  help(socket) {
+    let output = '';
+    output += '<span class="mediumOrchid">buy &lt;item name&gt </span><span class="purple">-</span> Buy an item from a shop. <br />';
+    socket.emit('output', { message: output });
+  },
+};

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -5,6 +5,7 @@ import config from '../config';
 let commandModules = [
   'attack.js',
   'break.js',
+  'buy.js',
   'catalog.js',
   'close.js',
   'create.js',
@@ -29,6 +30,7 @@ let commandModules = [
   'roll.js',
   'say.js',
   'search.js',
+  'sell.js',
   'set.js',
   'spawner.js',
   'spawn.js',

--- a/src/commands/sell.js
+++ b/src/commands/sell.js
@@ -1,0 +1,68 @@
+import Shop from '../models/shop';
+import autocomplete from '../core/autocomplete';
+
+export default {
+  name: 'sell',
+
+  patterns: [
+    /^sell\s+(.+)$/i,
+    /^sell\s.*/i,
+  ],
+
+  dispatch(socket, match) {
+    if (match.length != 2) {
+      this.help(socket);
+    }
+    this.execute(socket, match[1]);
+  },
+
+  execute(socket, itemName) {
+
+    // check if user has item
+    const acResult = autocomplete.autocompleteTypes(socket, ['inventory'], itemName);
+    if (!acResult) {
+      return;
+    }
+
+    const shop = Shop.getById(socket.character.roomId);
+    if (!shop) {
+      socket.emit('output', { message: 'This command can only be used in a shop.' });
+      return;
+    }
+
+    const itemType = shop.getItemTypeByAutocomplete(itemName);
+
+    // check if shop carries this type of item
+    const stockType = shop.stock.find(st => st.itemTypeName === itemType.name);
+    if (!stockType) {
+      socket.emit('output', { message: 'This shop does not deal in those types of items.' });
+      return;
+    }
+
+    // check if item can be sold
+    if (!itemType.price) {
+      socket.emit('output', { message: 'You cannot sell this item.' });
+      return;
+    }
+
+    const sellPrice = shop.getSellPrice(itemType);
+
+    // check if shop has money
+    if (shop.currency < sellPrice) {
+      socket.emit('output', { message: 'The shop cannot afford to buy that from you.' });
+      return;
+    }
+
+    shop.sell(socket.character, itemType);
+    if (sellPrice) {
+      socket.emit('output', { message: `You sold ${itemType.displayName} for ${sellPrice}.` });
+      socket.broadcast.to(socket.character.roomId).emit('output', { message: `${socket.user.username} sells ${itemType.displayName} to the shop.` });
+    }
+  },
+
+  help(socket) {
+    let output = '';
+    output += '<span class="mediumOrchid">sell &lt;item name&gt </span><span class="purple">-</span> sell an item to a shop. <br />';
+    socket.emit('output', { message: output });
+  },
+};

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -4,6 +4,12 @@ import Shop from '../models/shop';
 import lookCmd from './look';
 import autocomplete from '../core/autocomplete';
 
+function setCurrency(character, amount) {
+  character.currency = amount;
+  character.save(err => {
+    if(err) throw err;
+  });
+}
 
 function setRoom(socket, prop, value) {
   const room = Room.getById(socket.character.roomId);
@@ -65,6 +71,8 @@ export default {
     /^set\s+(room)\s+(alias)\s+(.+)$/i,
     /^set\s+(room)\s+(area)\s+(.+)$/i,
     /^set\s+(room)\s+(shop)$/i,
+    /^set\s+(currency)\s+(\d+)$/i,
+    
     /^set.*$/i,
   ],
 
@@ -86,6 +94,8 @@ export default {
 
     if (type === 'room') {
       setRoom(socket, prop, value);
+    } else if(type === 'currency') {
+      setCurrency(socket.character, prop); // prop is 'value' in this case
     }
     else {
       socket.emit('output', { message: 'Invalid type.' });

--- a/src/commands/spawn.js
+++ b/src/commands/spawn.js
@@ -4,6 +4,33 @@ import Mob from '../models/mob';
 import itemData from '../data/itemData';
 import Item from '../models/item';
 
+export const spawn = (itemType) => {
+  return new Item({
+    name: itemType.name,
+    desc: itemType.desc,
+    displayName: itemType.displayName,
+    type: itemType.type,
+    fixed: itemType.fixed,
+    equip: itemType.equip,
+    damage: itemType.damage,
+    damageType: itemType.damageType,
+    speed: itemType.speed,
+    bonus: itemType.bonus,
+  });
+};
+
+export const spawnAndGive = (character, itemType, cb) => {
+
+  const item = spawn(itemType);
+
+  character.inventory.push(item);
+  character.save((err, character) => {
+    if (err) throw err;
+    if (cb) cb(character);
+  });
+  return item;
+};
+
 export default {
   name: 'spawn',
   admin: true,
@@ -52,35 +79,17 @@ export default {
       socket.emit('output', { message: 'Summoning successful.' });
       socket.broadcast.to(room.id).emit('output', { message: `${socket.user.username} waves his hand and a ${createType.displayName} appears!` });
 
-
       // Item
       //---------------------
     } else if (type === 'item') {
-      const createType = itemData.catalog.find(item => item.name.toLowerCase() === name.toLowerCase() && item.type === 'item');
 
-      if (!createType) {
-        socket.emit('output', { message: 'Unknown item type.' });
+      const itemType = itemData.catalog.find(item => item.name.toLowerCase() === name.toLowerCase() && item.type === 'item');
+      if (!itemType) {
+        socket.emit('output', { message: `Attempted to spawn unknown item type: ${name}` });
         return;
       }
 
-      // Object.assign didn't seem to work properly when
-      // working with mongoose instances...
-      let item = new Item({
-        name: createType.name,
-        desc: createType.desc,
-        displayName: createType.displayName,
-        type: createType.type,
-        fixed: createType.fixed,
-        equip: createType.equip,
-        damage: createType.damage,
-        damageType: createType.damageType,
-        speed: createType.speed,
-        bonus: createType.bonus,
-      });
-
-
-      socket.character.inventory.push(item);
-      socket.character.save(err => { if (err) throw err; });
+      spawnAndGive(socket.character, itemType);
       socket.emit('output', { message: 'Item created.' });
       socket.broadcast.to(socket.character.roomId).emit('output', { message: `${socket.user.username} emits a wave of energy!` });
 

--- a/src/commands/spawn.spec.js
+++ b/src/commands/spawn.spec.js
@@ -36,7 +36,7 @@ describe('spawn', () => {
       test('should output message when type name is invalid', () => {
         sut.execute(socket, 'item', 'name');
 
-        expect(socket.emit).toBeCalledWith('output', { message: 'Unknown item type.' });
+        expect(socket.emit).toBeCalledWith('output', { message: 'Attempted to spawn unknown item type: name' });
       });
 
       test('should create instance of item in user inventory', () => {

--- a/src/commands/take.js
+++ b/src/commands/take.js
@@ -6,8 +6,6 @@ import utils from '../core/utilities';
 export default {
   name: 'take',
 
-  alias: [],
-
   patterns: [
     /^take\s+(.+)$/i,
     /^get\s+(.+)$/i,

--- a/src/core/autocomplete.js
+++ b/src/core/autocomplete.js
@@ -59,6 +59,17 @@ export default {
     return distinctSource.filter(value => !!re.exec(value[property]));
   },
 
+  autocompleteByProperties(source, propertyNames, fragment) {
+    const resultArr = [];
+    for (const prop of propertyNames) {
+      let results = this.autocompleteByProperty(source, prop, fragment);
+      resultArr.push(results);
+    }
+
+    const combArr = [].concat(...resultArr);
+    return [...new Set(combArr)];
+  },
+
   autocompleteTypes(socket, types, fragment) {
     for (const typeKey in types) {
       if (!types.hasOwnProperty(typeKey)) continue;
@@ -68,18 +79,14 @@ export default {
       if (!typeConfig) {
         throw `Invalid type: ${type}`;
       }
+
       let source = typeConfig.source(socket);
-
-      // Returning the first match among all the types involved.
-      for (const prop of typeConfig.propertyNames) {
-        let results = this.autocompleteByProperty(source, prop, fragment);
-
-        if (results.length > 0) {
-          return {
-            type,
-            item: results[0],
-          };
-        }
+      const results = this.autocompleteByProperties(source, typeConfig.propertyNames, fragment);
+      if (results.length > 0) {
+        return {
+          type,
+          item: results[0],
+        };
       }
     }
 

--- a/src/models/characterSchema.js
+++ b/src/models/characterSchema.js
@@ -87,7 +87,7 @@ const CharacterSchema = new mongoose.Schema({
     // shield from magic (resist spell, see through illusion/charm, etc) (WIL)
     resist: { type: Number },
   },
-});
+}, { usePushEach: true });
 
 CharacterSchema.methods.nextExp = function () {
   const BASE_XP = 300;

--- a/src/models/shopSchema.js
+++ b/src/models/shopSchema.js
@@ -1,4 +1,7 @@
 import mongoose from 'mongoose';
+import autocomplete from '../core/autocomplete';
+import itemData from '../data/itemData';
+import { spawnAndGive } from '../commands/spawn';
 
 const shopCache = {};
 
@@ -8,6 +11,7 @@ const ShopSchema = new mongoose.Schema({
     itemTypeName: { type: String, required: true },
     quantity: { type: Number, required: true, min: 0 },
   }],
+  currency: { type: Number, min: 0, default: 0 },
   owner: { String }, // this will be the NPC that owns the shop
 }, { usePushEach: true });
 
@@ -33,6 +37,105 @@ ShopSchema.statics.populateShopCache = function () {
     result.forEach(shop => {
       shopCache[shop.roomId] = shop;
     });
+  });
+};
+
+ShopSchema.methods.getStockTypes = function () {
+  return this.stock.map(s => {
+    const itemType = itemData.catalog.find(
+      item => item.name.toLowerCase() === s.itemTypeName.toLowerCase()
+        && item.type === 'item');
+    return Object.assign(s, { itemType: itemType });
+  });
+};
+
+ShopSchema.methods.getItemTypeByAutocomplete = function (itemName) {
+  const stockTypes = this.getStockTypes();
+  const itemTypes = stockTypes.map(st => st.itemType);
+
+  const acResult = autocomplete.autocompleteByProperty(itemTypes, 'displayName', itemName);
+  if (Array.isArray(acResult) && acResult.length > 0) {
+    return acResult[0];
+  }
+};
+
+ShopSchema.methods.buy = function (character, itemType) {
+
+  const stockType = this.stock.find(st => st.itemTypeName === itemType.name);
+  if (!stockType) {
+    return;
+  }
+
+  // item is out of stock
+  if (stockType.quantity === 0) {
+    return;
+  }
+
+  // character doesn't have enough money
+  if (character.currency < itemType.price) {
+    return;
+  }
+
+  // update shop
+  this.currency += itemType.price;
+  stockType.quantity--;
+
+  // update player
+  character.currency -= itemType.price;
+
+  this.save((err) => {
+    if (err) throw err;
+  });
+
+  const item = spawnAndGive(character, itemType);
+
+  return item;
+};
+
+ShopSchema.methods.getSellPrice = function (itemType) {
+  return Math.round(itemType.price * 0.6);
+};
+
+ShopSchema.methods.sell = function (character, itemType) {
+
+  // check if character is carrying the item
+  const item = character.inventory.find(i => i.name === itemType.name);
+  if (!item) {
+    return;
+  }
+
+  // check if item can be sold
+  if (!itemType.price) {
+    return;
+  }
+
+  // check if shop carries this type of item
+  const stockType = this.stock.find(st => st.itemTypeName === itemType.name);
+  if (!stockType) {
+    return;
+  }
+
+  const sellPrice = this.getSellPrice(itemType);
+
+  // shop doesn't have enough money
+  if (this.currency < sellPrice) {
+    return;
+  }
+
+  // update shop
+  this.currency -= sellPrice;
+  stockType.quantity++;
+
+  // update player
+  character.currency += sellPrice;
+
+  this.save((err) => {
+    if (err) throw err;
+  });
+
+  character.inventory.id(item.id).remove();
+  character.save(err => {
+    if (err) throw err;
   });
 };
 


### PR DESCRIPTION
New commands:
```
set room shop - makes the current room a shop
list - lists shop inventory (previous list command is now 'catalog')
stock <item name> <quantity> - admin can give shop inventory with this command.
buy <item name> - buy items from a shop
sell <item name> - sell items back to the shop (currently at 60% of their purchased valued)
set currency <amount> - give yourself some money!
```
Highlights:
- An ascii table module has been added to the project. This is used in the list command.
- Autocomplete was further modularized to make it more reusable.
- Spawn now has an exported utility method you can use to produce instances of types from the - item/mob catalogs.

To-do:
- New commands still need tests

Resolves #113 
Resolves #114 